### PR TITLE
LIA-44687 splice out any extraneous sub-folders when determining the …

### DIFF
--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -38,6 +38,7 @@ var JS_SPEC_PATTERN = 'src/**/*.spec.js';
 var TPL_MAIN_PATTERN = 'src/**/!(*.demo).tpl.html';
 var TPL_DEMO_PATTERN = 'src/directives/**/*.demo.tpl.html';
 var BASE = 'src';
+var EXPECTED_MODULE_PARTS = 4;
 
 module.exports = function (gulp, gutil) {
 
@@ -84,7 +85,8 @@ module.exports = function (gulp, gutil) {
                      * the same name.
                      */
                     url = file.path.substr(path().join(file.cwd, 'src').length + 1);
-                    moduleType = 'services'
+                    moduleType = 'services';
+
                   } else {
                     url = file.path.substr(path().join(file.cwd, 'src', 'directives').length + 1);
                     moduleType = 'directives';
@@ -92,13 +94,44 @@ module.exports = function (gulp, gutil) {
 
                   file.contents = new Buffer(gutil.template(HTML2JS_TEMPLATE)({
                     moduleName: (function () {
+
                       var parts = file.path.split('/');
+
+                      /**
+                       * services/common/form-type-registry/fields/inputs/input.tpl.html
+                       *
+                       * The parts array is used to generate the moduleName for the templateCache entry. When
+                       * subfolders are in the parts array, the moduleName incorrectly includes them, making the
+                       * templateCache invalid. Look for the presence of sub-folders within the module by determining
+                       * the number of path parts between the moduleType's index (service or directive) and the end of
+                       * the path parts array. If there are more than 4, remove these from the array starting at the
+                       * next-to-last position:
+                       *
+                       * parts (original)
+                       * [ '', 'src', 'services', 'common', 'form-type-registry', 'fields', 'inputs', 'input.tpl.html' ]
+                       *
+                       * parts (modified)
+                       * [ '', 'src', 'services', 'common', 'form-type-registry', 'input.tpl.html' ]
+                       *
+                       * From this, the moduleName will be correctly set as li.services.common.form-type-registry
+                       *
+                       **/
+
+                      var numParts = parts.length;
+                      var moduleTypeIndex = parts.indexOf(moduleType);
+                      var diff = (numParts - moduleTypeIndex) - EXPECTED_MODULE_PARTS;
+
+                      if (diff > 0) {
+                        parts.splice((diff + 1) * -1, diff);
+                      }
+
                       return [
                         gutil.env.ng.module,
                         moduleType,
                         parts[parts.length - 3],
                         parts[parts.length - 2]
                       ].join('.');
+
                     })(),
                     prettyEscapedContent: getPrettyEscapedContent(String(file.contents)),
                     file: file,


### PR DESCRIPTION
From JIRA:

templateCache entries are defined within an angular module. When processing tpl.html files for forms, if any of these files are within sub-folders (for organization purposes), the script for creating templateCache entries incorrectly includes the subfolders as part of the moduleName. Without this fix, templaceCache entries aren't found for any tpl.html files within subfolders.