### PR TITLE
Fix common.init README with proper filename description

### DIFF
--- a/templates/project/res/init/_README.md
+++ b/templates/project/res/init/_README.md
@@ -1,4 +1,4 @@
-This folder is intended for a specific file named common.init.ftl.
+This folder is intended for a specific file named Common.init.ftl.
 
 This file enables you to execute business logic using FreeMarker early in a request prior to any HTML being rendered. The script runs once each request, server side, and is often used for redirecting to a different page and reskinning pages in the community.
 Let's say you want to redirect anonymous users coming to the community to a custom landing page you've added through Studio, and direct any registered users a different landing page. The FreeMarker code you would add might look like this:
@@ -10,6 +10,6 @@ Let's say you want to redirect anonymous users coming to the community to a cust
  ${http.response.setRedirectUrl(community.urls.frontPage)}
 </#if>
 
-Alternatively, you can edit common.init.ftl in Studio > Advanced > Page Initialization.
+Alternatively, you can edit Common.init.ftl in Studio > Advanced > Page Initialization.
 
 Warning: The Page Initialization Script is an advanced tool, and in some cases might contain code that has been created for you by Lithium Services for community customizations. Do not edit any code that you might see by default without first consulting Lithium Services or Support. We strongly recommend consulting with Lithium before using the script.


### PR DESCRIPTION
Naming the file common.init.ftl results in a package error

```
[10:30:27] ✗ FAIL: res/init/common.init.ftl is unexpected
[10:30:27] Tested 364 tests, 363 passes, 1 failures: FAIL
```