### PR TITLE
LIA-84149-fix local-server gulp task to not have sub gulp-tasks

### DIFF
--- a/gulp/checkThemes.js
+++ b/gulp/checkThemes.js
@@ -5,16 +5,24 @@ module.exports = function (gulp, gutil) {
    * Checks if a theme skin is enabled
    */
 
-  var supportedMinVersionForThemeCheck = '22.7';
   gulp.task('check-themes', ['version-check'], function(cb, errorCallback) {
     var server = require('../lib/server.js')(gulp, gutil);
-    var version = require('../lib/version-check')(gulp, gutil).getVersion();
-    if (version >= supportedMinVersionForThemeCheck) {
-    	require('../lib/check-themes.js')(gulp, gutil).process(server, {
-	      debugMode: gutil.env.debug
-	    }, cb, errorCallback);
-    } else {
-    	return cb();
+    if (server.useLocalCompile()) {
+        var version = require('../lib/version-check')(gulp, gutil).getVersion();
+        var serverVersionThemeCheck = require('../lib/server-version-theme-check.json');
+        var versionPattern = /(\d+)\.(\d{0,2})*/i;
+        var matches = version.toString().match(versionPattern);
+        var versionOnServer = parseInt(matches[1]);
+        var minorVersionOnServer = parseInt(matches[2]);
+        if (versionOnServer >= serverVersionThemeCheck.supportedVersionMajor ||
+            (versionOnServer == serverVersionThemeCheck.supportedVersionMajor &&
+            minorVersionOnServer >= serverVersionThemeCheck.supportedVersionMinor)) {
+            require('../lib/check-themes.js')(gulp, gutil).process(server, {
+              debugMode: gutil.env.debug
+            }, cb, errorCallback);
+        } else {
+            return cb();
+        }
     }
   });
 };

--- a/gulp/local-server.js
+++ b/gulp/local-server.js
@@ -8,7 +8,7 @@ module.exports = function (gulp, gutil) {
   var server = require('../lib/server.js')(gulp, gutil);
   var lrListening;
 
-  gulp.task('local-server', ['check-themes'], function (cb) {
+  gulp.task('local-server', function (cb) {
     if (server.useLocalCompile()) {
       if (!lrListening) {
         lrListening = true;

--- a/gulp/plugin.js
+++ b/gulp/plugin.js
@@ -170,5 +170,9 @@ module.exports = function (gulp, gutil) {
     'skins'
   ]);
 
-  gulp.task('serve-sass', ['skins-compile', 'watch-res-sass', 'local-server']);
+  gulp.task('serve-sass', function(done) {
+      runSequence('skins-compile', 'watch-res-sass', 'local-server', function() {
+          done();
+      });
+  });
 };

--- a/lib/server-version-theme-check.json
+++ b/lib/server-version-theme-check.json
@@ -1,0 +1,4 @@
+{
+  "supportedVersionMajor": "22",
+  "supportedVersionMinor": "7"
+}

--- a/lib/skin.js
+++ b/lib/skin.js
@@ -20,8 +20,9 @@ module.exports = function (gulp, gutil) {
   var communityPluginsDir = 'other';
   var propFileName = 'skin.properties';
   var checkTheme, version;
-  var supportedMinVersionForThemeCheck = '22.7';
   var themesMap;
+  var serverVersionThemeCheck = require('../lib/server-version-theme-check.json');
+  var versionPattern = /(\d+)\.(\d{0,2})*/i;
   
   function isEmpty(obj) {
     return Object.keys(obj).length === 0;
@@ -303,7 +304,12 @@ module.exports = function (gulp, gutil) {
         var parentId = this.getParentId();
         if (parentId) {
           if (parentId.includes("theme")) {
-            if (version < supportedMinVersionForThemeCheck) {
+            var matches = version.toString().match(versionPattern);
+            var versionOnServer = parseInt(matches[1]);
+            var minorVersionOnServer = parseInt(matches[2]);
+            if (versionOnServer < serverVersionThemeCheck.supportedVersionMajor ||
+                    (versionOnServer == serverVersionThemeCheck.supportedVersionMajor &&
+                    minorVersionOnServer < serverVersionThemeCheck.supportedVersionMinor)) {
               isTheme = true;
               return null;
             }

--- a/lib/version-check.js
+++ b/lib/version-check.js
@@ -6,9 +6,10 @@ var defaultVersion = require('./server-version.json');
 var sdkVersion = '1.0.2';
 var putils = require('./plugin-utils');
 var liaVersion;
-var supportedMinVersionForThemeCheck = '22.7';
+var serverVersionThemeCheck = require('./server-version-theme-check.json');
 
 module.exports = function (gulp, gutil) {
+  var server = require('./server.js')(gulp, gutil);
   var versionPattern = /(\d+)\.(\d{0,2})*/i;
   function validate(serverUrl, pluginToken, opts, cb, errorCallback) {
 
@@ -19,6 +20,11 @@ module.exports = function (gulp, gutil) {
       rejectUnauthorized: false
     };
     var serverVersion = opts.version === undefined ? defaultVersion : opts.version;
+
+    if (pluginToken == null) {
+        putils.logDebug(gutil, 'Either sdk is not enabled or plugin token is not provided, pluginToken should be provided for sdk plugin projects');
+        return;
+    }
 
     var versionCheckUrl = pluginUtils.urlBldr(serverUrl + '/restapi/ldntool/plugins/version?format=json').build();
     if (opts.debugMode) {
@@ -59,9 +65,11 @@ module.exports = function (gulp, gutil) {
           callbackOrThrowError(errorCallback, errorMessage);
         }
 
-        if (version < supportedMinVersionForThemeCheck) {
+        if (versionOnServer < serverVersionThemeCheck.supportedVersionMajor ||
+                  (versionOnServer == serverVersionThemeCheck.supportedVersionMajor &&
+                  minorVersionOnServer < serverVersionThemeCheck.supportedVersionMinor)) {
           putils.logWarning(gutil, "This version of community doesn't support rendering custom theme skins! Pls upgrade your community to version " +
-            supportedMinVersionForThemeCheck + " or newer to get this feature.");
+            serverVersionThemeCheck.supportedVersionMajor + '.' + serverVersionThemeCheck.supportedVersionMinor + " or newer to get this feature.");
         }
 
         //On success invoke callback function


### PR DESCRIPTION
Angular-li gulp cmd is failing when running the gulp task `local-server` asking for sdk plugin token to be provided in server.conf.json. This is because `local-server` has a sub gulp task `check-themes`. This internally calls another gulp task `version-check` which requires the plugin token to be present. Fixed to removed the dependency on `check-themes` gulp task from `local-server`.